### PR TITLE
Support for annotations in service

### DIFF
--- a/charts/dependency-track/Chart.yaml
+++ b/charts/dependency-track/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   Dependency-Track is an intelligent Software Supply Chain Component Analysis platform that allows organizations to identify and reduce risk from the use of third-party and open source components. Dependency-Track takes a unique and highly beneficial approach by leveraging the capabilities of Software Bill-of-Materials (SBOM). This approach provides capabilities that traditional Software Composition Analysis (SCA) solutions cannot achieve.
 name: dependency-track
 home: https://dependencytrack.org/
-version: 0.2.2
+version: 0.2.3
 icon: https://www.owasp.org/images/e/e9/Dependency-Track-logo-large.png
 keywords:
  - security

--- a/charts/dependency-track/templates/service.yaml
+++ b/charts/dependency-track/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "dependency-track.fullname" . }}
   labels:
 {{ include "dependency-track.labels" . | indent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -43,6 +43,8 @@ securityContext:
 service:
   type: ClusterIP
   port: 80
+  annotations: {}
+    # cloud.google.com/load-balancer-type: "Internal"
 
 ingress:
   enabled: false


### PR DESCRIPTION
In a mixed environment it is sometimes necessary to route traffic from Services inside the same (virtual) network address block.  
It is useful to be able to set the `service` to `annotations` in that case.
