### PR TITLE
Fix not able to use iam policy (#17)

### DIFF
--- a/charts/ecr-proxy/Chart.yaml
+++ b/charts/ecr-proxy/Chart.yaml
@@ -32,7 +32,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ecr-proxy/ci/no-secrets.yaml
+++ b/charts/ecr-proxy/ci/no-secrets.yaml
@@ -1,0 +1,9 @@
+env:
+  - name: UPSTREAM
+    value: https://someaccount.dkr.ecr.eu-north-1.amazonaws.com
+  - name: AWS_REGION
+    value: eu-north-1
+  - name: RESOLVER
+    value: kube-dns.kube-system.svc
+secret:
+  create: false

--- a/charts/ecr-proxy/templates/deployment.yaml
+++ b/charts/ecr-proxy/templates/deployment.yaml
@@ -50,6 +50,7 @@ spec:
           env:
             - name: PORT
               value: "80"
+            {{- if .Values.secret.create }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -60,6 +61,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "ecr-proxy.secretName" . }}
                   key: AWS_SECRET_ACCESS_KEY
+            {{- end }}
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
**What**:
* Previously not able to use IAM role and helm not able to deploy without defining aws access key and secret key
* Now able to use IAM role, so defining aws access key and secret key not compulsory
* ~~Also update commented values in  `values.yaml` to remove confusion of env for aws access key and secret key~~ (As discussed below)

**Why**:
* Closes #17  