### PR TITLE
Fix runner-operator crds

### DIFF
--- a/charts/github-actions-runner-operator/Chart.yaml
+++ b/charts/github-actions-runner-operator/Chart.yaml
@@ -30,7 +30,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.2
+version: 2.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/github-actions-runner-operator/crds/garo.tietoevry.com_githubactionrunners.yaml
+++ b/charts/github-actions-runner-operator/crds/garo.tietoevry.com_githubactionrunners.yaml
@@ -1279,6 +1279,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -3597,6 +3598,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:


### PR DESCRIPTION
Fix:
`
Error: failed to install CRD crds/garo.tietoevry.com_githubactionrunners.yaml: CustomResourceDefinition.apiextensions.k8s.io "githubactionrunners.garo.tietoevry.com" is invalid: [spec.validation.openAPIV3Schema.properties[spec].properties[podTemplateSpec].properties[spec].properties[containers].items.properties[ports].items.properties[protocol].default: Required value: this property is in x-kubernetes-list-map-keys, so it must have a default or be a required property, spec.validation.openAPIV3Schema.properties[spec].properties[podTemplateSpec].properties[spec].properties[initContainers].items.properties[ports].items.properties[protocol].default: Required value: this property is in x-kubernetes-list-map-keys, so it must have a default or be a required property]
`