### PR TITLE
Fix issue with existing secret

### DIFF
--- a/charts/github-actions-runner-operator/Chart.yaml
+++ b/charts/github-actions-runner-operator/Chart.yaml
@@ -30,7 +30,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.0
+version: 2.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/github-actions-runner-operator/templates/secret.yaml
+++ b/charts/github-actions-runner-operator/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.githubapp.enabled }}
+{{- if and .Values.githubapp.enabled (not .Values.githubapp.existingSecret) }}
 apiVersion: v1
 kind: Secret
 type: Opaque


### PR DESCRIPTION
```
 helm install github-actions-runner-operator evryfs-oss/github-actions-runner-operator --namespace github-actions-runner --set githubapp.existingSecret=github-app-private-key --set githubapp.enabled=true
Error: template: github-actions-runner-operator/templates/secret.yaml:12:38: executing "github-actions-runner-operator/templates/secret.yaml" at <b64enc>: invalid value; expected string
```