### PR TITLE
Support installing CRD via helm

### DIFF
--- a/charts/github-actions-runner-operator/Chart.yaml
+++ b/charts/github-actions-runner-operator/Chart.yaml
@@ -30,7 +30,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.4
+version: 2.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/github-actions-runner-operator/templates/crds.yaml
+++ b/charts/github-actions-runner-operator/templates/crds.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.installCRDs }}
+{{- range $path, $_ := .Files.Glob "crds/*.yaml" }}
+{{ $.Files.Get $path }}
+---
+{{- end }}
+{{- end }}

--- a/charts/github-actions-runner-operator/values.yaml
+++ b/charts/github-actions-runner-operator/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Install CustomCRDs
+installCRDs: false
+
 image:
   repository: quay.io/evryfs/github-actions-runner-operator
   pullPolicy: IfNotPresent


### PR DESCRIPTION
We're using helm in ArgoCD to manage our systems, and it's nice to be able to do:

```yaml
my-runner:
  installCRDs: true
```

And have the CRD get installed with everything else.