### PR TITLE
Change indent -> nident

### DIFF
--- a/charts/github-actions-runner-operator/Chart.yaml
+++ b/charts/github-actions-runner-operator/Chart.yaml
@@ -30,7 +30,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.8
+version: 2.5.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/github-actions-runner-operator/templates/deployment.yaml
+++ b/charts/github-actions-runner-operator/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - name: GITHUB_V4_API_URL
               value: {{ .Values.github.apiEndpoint }}
             {{- with .Values.extraEnv }}
-            {{ toYaml . | indent 12 }}
+            {{ toYaml . | nindent 12 }}
             {{- end }}
           ports:
             - name: metrics


### PR DESCRIPTION
This fixes current error with indent usage causing:
'error converting YAML to JSON: yaml: line 53: mapping values
are not allowed in this context'