### PR TITLE
OpenShift Compatibility

### DIFF
--- a/charts/dependency-track/Chart.yaml
+++ b/charts/dependency-track/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   Dependency-Track is an intelligent Software Supply Chain Component Analysis platform that allows organizations to identify and reduce risk from the use of third-party and open source components. Dependency-Track takes a unique and highly beneficial approach by leveraging the capabilities of Software Bill-of-Materials (SBOM). This approach provides capabilities that traditional Software Composition Analysis (SCA) solutions cannot achieve.
 name: dependency-track
 home: https://dependencytrack.org/
-version: 1.0.4
+version: 1.0.5
 icon: https://raw.githubusercontent.com/DependencyTrack/branding/master/dt-logo-black-text.svg
 keywords:
  - security

--- a/charts/dependency-track/Chart.yaml
+++ b/charts/dependency-track/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
-appVersion: 4.2.0
+appVersion: 4.2.1
 description: |
   Dependency-Track is an intelligent Software Supply Chain Component Analysis platform that allows organizations to identify and reduce risk from the use of third-party and open source components. Dependency-Track takes a unique and highly beneficial approach by leveraging the capabilities of Software Bill-of-Materials (SBOM). This approach provides capabilities that traditional Software Composition Analysis (SCA) solutions cannot achieve.
 name: dependency-track
 home: https://dependencytrack.org/
-version: 1.0.3
+version: 1.0.4
 icon: https://raw.githubusercontent.com/DependencyTrack/branding/master/dt-logo-black-text.svg
 keywords:
  - security

--- a/charts/dependency-track/README.md
+++ b/charts/dependency-track/README.md
@@ -4,7 +4,7 @@
 To install this chart on Kubernetes, use the following commands:
 ```
 kubectl create namespace dependency-track
-helm install dependency-track evryfs-oss/dependency-track [--set ingress.enabled=true --set ingress.host=<desired_URL>] --namespace dependency-track
+helm install dependency-track evryfs-oss/dependency-track [--set ingress.enabled=true --set ingress.host=<desired_fqdn>] --namespace dependency-track
 ```
 
 **Note:** Depending on how you install the chart, the `API_BASE_URL` value in values.yaml may need to be amended.

--- a/charts/dependency-track/README.md
+++ b/charts/dependency-track/README.md
@@ -23,7 +23,12 @@ helm install dependency-track evryfs-oss/dependency-track [--set ingress.enabled
 
 To install this chart on OpenShift using the Restricted SCC, use the following command:
 ```
-helm install dependency-track evryfs-oss/dependency-track --set apiserver.podSecurityContext.enabled=false --set apiserver.securityContext.enabled=false --set frontend.securityContext.enabled=false --set frontend.podSecurityContext.enabled=false [--set ingress.enabled=true --set ingress.host=<desired_URL>]
+helm install dependency-track evryfs-oss/dependency-track --set apiserver.podSecurityContext.enabled=false \
+   --set apiserver.securityContext.enabled=false --set frontend.securityContext.enabled=false \
+   --set frontend.podSecurityContext.enabled=false [--set ingress.enabled=true --set ingress.host=<desired_URL>] \
+   --set postgresql.serviceAccount.enabled=true --set postgresql.containerSecurityContext.enabled=false \
+   --set postgresql.securityContext.enabled=false --set postgresql.volumePermissions.enabled=true \
+   --set postgresql.volumePermissions.securityContext.runAsUser="auto"
 ```
 
 **Note:** To use the chart with the Restricted SCC it requires changes to the Frontend and Backend Dockerfiles to be compatible. PRs have been raised and these will need to be merged and released before installation under Restricted SCC can take place.

--- a/charts/dependency-track/README.md
+++ b/charts/dependency-track/README.md
@@ -1,13 +1,39 @@
 # Dependency-track
 
 ## Installing
-
+To install this chart on Kubernetes, use the following commands:
 ```
 kubectl create namespace dependency-track
-helm install dependency-track evryfs-oss/dependency-track --namespace dependency-track
+helm install dependency-track evryfs-oss/dependency-track [--set ingress.enabled=true --set ingress.host=<desired_URL>] --namespace dependency-track
 ```
 
-## Configuration
+**Note:** Depending on how you install the chart, the `API_BASE_URL` value in values.yaml may need to be amended.
+ - If `ingress.enabled=true` then it can be left as `API_BASE_URL=""`
+ - If ingress is not used, or separate ingress URLs are desired for the frontend and backend, then the `API_BASE_URL` will need to be set as the URL for the Backend
+ - If you wish to use port-forwarding then `API_BASE_URL=http://127.0.0.1:<port>`, see values.yaml for more information
 
+To install this chart on OpenShift, using the `anyuid` or `nonroot` SCCs, use the following commands (choosing anyuid or nonroot as the SCC):
+```
+oc adm policy add-scc-to-user <anyuid|nonroot> -z dependency-track-frontend
+oc adm policy add-scc-to-user <anyuid|nonroot> -z dependency-track-apiserver
+oc adm policy add-scc-to-user <anyuid|nonroot> -z dependency-track-postgresql
+oc create namespace dependency-track
+helm install dependency-track evryfs-oss/dependency-track [--set ingress.enabled=true] --namespace dependency-track
+```
+
+**Note:** If you change the release name from `dependency-track` then the service accounts will have a different name, e.g. `<release_name>-frontend`.
+
+To install this chart on OpenShift using the Restricted SCC, use the following command:
+```
+helm install dependency-track evryfs-oss/dependency-track --set apiserver.podSecurityContext.enabled=false --set apiserver.securityContext.enabled=false --set frontend.securityContext.enabled=false --set frontend.podSecurityContext.enabled=false [--set ingress.enabled=true --set ingress.host=<desired_URL>]
+```
+
+**Note:** To use the chart with the Restricted SCC it requires changes to the Frontend and Backend Dockerfiles to be compatible. PRs have been raised and these will need to be merged and released before installation under Restricted SCC can take place.
+ - https://github.com/DependencyTrack/dependency-track/pull/994
+ - https://github.com/DependencyTrack/frontend/pull/67 
+
+Therefore as of release 4.2.1, these PRs have not yet been released.
+
+## Configuration
 PostgreSQL is enabled by default.
 See [values.yaml](values.yaml) for configuration parameters.

--- a/charts/dependency-track/README.md
+++ b/charts/dependency-track/README.md
@@ -35,5 +35,8 @@ helm install dependency-track evryfs-oss/dependency-track --set apiserver.podSec
 Therefore as of release 4.2.1, these PRs have not yet been released.
 
 ## Configuration
-PostgreSQL is enabled by default.
+PostgreSQL is enabled by default. In conjunction with PostgreSQL, by default in initContainer `wait-for-db` is enabled and configured to check the database is up before the frontend and backend are started.
+
+If this is not required, it can be disabled via `--set apiserver.initContainers.enabled=false --set frontend.initContainers.enabled=false` at install time.
+
 See [values.yaml](values.yaml) for configuration parameters.

--- a/charts/dependency-track/README.md
+++ b/charts/dependency-track/README.md
@@ -25,7 +25,7 @@ To install this chart on OpenShift using the Restricted SCC, use the following c
 ```
 helm install dependency-track evryfs-oss/dependency-track --set apiserver.podSecurityContext.enabled=false \
    --set apiserver.securityContext.enabled=false --set frontend.securityContext.enabled=false \
-   --set frontend.podSecurityContext.enabled=false [--set ingress.enabled=true --set ingress.host=<desired_URL>] \
+   --set frontend.podSecurityContext.enabled=false [--set ingress.enabled=true --set ingress.host=<desired_fqdn>] \
    --set postgresql.serviceAccount.enabled=true --set postgresql.containerSecurityContext.enabled=false \
    --set postgresql.securityContext.enabled=false --set postgresql.volumePermissions.enabled=true \
    --set postgresql.volumePermissions.securityContext.runAsUser="auto"

--- a/charts/dependency-track/README.md
+++ b/charts/dependency-track/README.md
@@ -12,12 +12,10 @@ helm install dependency-track evryfs-oss/dependency-track [--set ingress.enabled
  - If ingress is not used, or separate ingress URLs are desired for the frontend and backend, then the `API_BASE_URL` will need to be set as the URL for the Backend
  - If you wish to use port-forwarding then `API_BASE_URL=http://127.0.0.1:<port>`, see values.yaml for more information
 
-To install this chart on OpenShift, using the `anyuid` or `nonroot` SCCs, use the following commands (choosing anyuid or nonroot as the SCC):
+To install this chart on OpenShift, using the `nonroot` SCC, use the following command:
 ```
-oc adm policy add-scc-to-user <anyuid|nonroot> -z dependency-track-frontend
-oc adm policy add-scc-to-user <anyuid|nonroot> -z dependency-track-apiserver
-oc adm policy add-scc-to-user <anyuid|nonroot> -z dependency-track-postgresql
 oc create namespace dependency-track
+oc create rolebinding nonroot --clusterrole=system:openshift:scc:nonroot --serviceaccount=<namespace>:dependency-track-frontend --serviceaccount=<namespace>:dependency-track-apiserver --serviceaccount=<namespace>:dependency-track-postgresql
 helm install dependency-track evryfs-oss/dependency-track [--set ingress.enabled=true] --namespace dependency-track
 ```
 

--- a/charts/dependency-track/templates/backend/deployment.yaml
+++ b/charts/dependency-track/templates/backend/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         resources: {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- if .Values.postgresql.enabled }}
-        command: ["/bin/sh", "-c", "for i in $(seq 1 200); do nc -z -w3 {{ .Release.Name}}-postgresql 5432 && exit 0 || sleep 2; done; exit 1"]
+        command: ['/bin/sh', '-c', 'for i in $(seq 1 200); do nc -z -w3 {{ .Release.Name}}-postgresql 5432 && exit 0 || sleep 2; done; exit 1']
         {{- else }}
         command: ["{{ .Values.initContainer.command }}"]
         {{- end }}

--- a/charts/dependency-track/templates/backend/deployment.yaml
+++ b/charts/dependency-track/templates/backend/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         resources: {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- if .Values.postgresql.enabled }}
-        command: ['/bin/sh', '-c', 'for i in $(seq 1 200); do nc -z -w3 {{ .Release.Name}}-postgresql 5432 && exit 0 || sleep 2; done; exit 1']
+        command: ["/bin/sh", "-c", "for i in $(seq 1 200); do nc -z -w3 {{ .Release.Name}}-postgresql 5432 && exit 0 || sleep 2; done; exit 1"]
         {{- else }}
         command: ["{{ .Values.initContainer.command }}"]
         {{- end }}

--- a/charts/dependency-track/templates/backend/deployment.yaml
+++ b/charts/dependency-track/templates/backend/deployment.yaml
@@ -30,7 +30,11 @@ spec:
         {{- with .Values.initContainer.resources }}
         resources: {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- if .Values.postgresql.enabled }}
         command: ["/bin/sh", "-c", "for i in $(seq 1 200); do nc -z -w3 {{ .Release.Name}}-postgresql 5432 && exit 0 || sleep 2; done; exit 1"]
+        {{- else }}
+        command: ["{{ .Values.initContainer.command }}"]
+        {{- end }}
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-apiserver

--- a/charts/dependency-track/templates/backend/deployment.yaml
+++ b/charts/dependency-track/templates/backend/deployment.yaml
@@ -19,13 +19,24 @@ spec:
       imagePullSecret: {{- toYaml . | nindent 6 }}
       {{- end }}
       serviceAccountName: {{ include "common.names.fullname" . }}-apiserver
-      securityContext: {{- toYaml .Values.apiserver.podSecurityContext | nindent 8 }}
-      {{- with .Values.apiserver.initContainers }}
-      initContainers: {{- toYaml . | nindent 6 }}
+      {{- if .Values.apiserver.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.apiserver.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.apiserver.initContainers.enabled }}
+      initContainers:
+      - name: "{{ .Values.initContainer.name }}"
+        image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
+        imagePullPolicy: "{{ .Values.initContainer.image.pullPolicy }}"
+        {{- with .Values.initContainer.resources }}
+        resources: {{- toYaml . | nindent 10 }}
+        {{- end }}
+        command: ["/bin/sh", "-c", "for i in $(seq 1 200); do nc -z -w3 {{ .Release.Name}}-postgresql 5432 && exit 0 || sleep 2; done; exit 1"]
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-apiserver
-        securityContext: {{- toYaml .Values.apiserver.securityContext | nindent 12 }}
+        {{- if .Values.apiserver.securityContext.enabled }}
+        securityContext: {{- omit .Values.apiserver.securityContext "enabled" | toYaml | nindent 12 }}
+        {{- end }}
         image: {{ include "apiserver.image" . }}
         imagePullPolicy: {{ .Values.apiserver.image.pullPolicy }}
         {{- with .Values.apiserver.resources }}

--- a/charts/dependency-track/templates/frontend/deployment.yaml
+++ b/charts/dependency-track/templates/frontend/deployment.yaml
@@ -15,10 +15,24 @@ spec:
       imagePullSecrets: {{- toYaml . | nindent 6 }}
       {{- end }}
       serviceAccountName: {{ include "common.names.fullname" . }}-frontend
-      securityContext: {{- toYaml .Values.frontend.podSecurityContext | nindent 8 }}
+      {{- if .Values.frontend.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.frontend.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.frontend.initContainers.enabled }}
+      initContainers:
+      - name: "{{ .Values.initContainer.name }}"
+        image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
+        imagePullPolicy: "{{ .Values.initContainer.image.pullPolicy }}"
+        {{- with .Values.initContainer.resources }}
+        resources: {{- toYaml . | nindent 10 }}
+        {{- end }}
+        command: ["/bin/sh", "-c", "for i in $(seq 1 200); do nc -z -w3 {{ .Release.Name}}-postgresql 5432 && exit 0 || sleep 2; done; exit 1"]
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}-frontend
-        securityContext: {{- toYaml .Values.frontend.securityContext | nindent 12 }}
+        {{- if .Values.frontend.securityContext.enabled }}
+        securityContext: {{- omit .Values.frontend.securityContext "enabled" | toYaml | nindent 12 }}
+        {{- end }}
         {{- with .Values.frontend.resources }}
         resources: {{ . | toYaml | nindent 10 }}
         {{- end }}

--- a/charts/dependency-track/templates/frontend/deployment.yaml
+++ b/charts/dependency-track/templates/frontend/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         resources: {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- if .Values.postgresql.enabled }}
-        command: ['/bin/sh', '-c', 'for i in $(seq 1 200); do nc -z -w3 {{ .Release.Name}}-postgresql 5432 && exit 0 || sleep 2; done; exit 1']
+        command: ["/bin/sh", "-c", "for i in $(seq 1 200); do nc -z -w3 {{ .Release.Name}}-postgresql 5432 && exit 0 || sleep 2; done; exit 1"]
         {{- else }}
         command: ["{{ .Values.initContainer.command }}"]
         {{- end }}

--- a/charts/dependency-track/templates/frontend/deployment.yaml
+++ b/charts/dependency-track/templates/frontend/deployment.yaml
@@ -26,7 +26,11 @@ spec:
         {{- with .Values.initContainer.resources }}
         resources: {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- if .Values.postgresql.enabled }}
         command: ["/bin/sh", "-c", "for i in $(seq 1 200); do nc -z -w3 {{ .Release.Name}}-postgresql 5432 && exit 0 || sleep 2; done; exit 1"]
+        {{- else }}
+        command: ["{{ .Values.initContainer.command }}"]
+        {{- end }}
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-frontend

--- a/charts/dependency-track/templates/frontend/deployment.yaml
+++ b/charts/dependency-track/templates/frontend/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         resources: {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- if .Values.postgresql.enabled }}
-        command: ["/bin/sh", "-c", "for i in $(seq 1 200); do nc -z -w3 {{ .Release.Name}}-postgresql 5432 && exit 0 || sleep 2; done; exit 1"]
+        command: ['/bin/sh', '-c', 'for i in $(seq 1 200); do nc -z -w3 {{ .Release.Name}}-postgresql 5432 && exit 0 || sleep 2; done; exit 1']
         {{- else }}
         command: ["{{ .Values.initContainer.command }}"]
         {{- end }}

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -155,6 +155,7 @@ initContainer:
     requests:
       cpu: 100m
       memory: 200Mi
+  command: []
 
 ingress:
   enabled: false

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -28,10 +28,19 @@ frontend:
   env:
     - name: API_BASE_URL
       value: ""
+    # Note: leave this blank if you are using the ingress provided by this chart-example
+    # If you don't use the ingress (or route in OpenShift) then set this to be "http://127.0.0.1:8081" and use port-forwarding
+    # This avoids exposing the apiserver to the Internet.
+    # To use DepTrack, you will need to "<kubectl|oc> port-forward svc/<release-name>-frontend 8080:80" and at the same time "<kubectl|oc> port-forward svc/<release-name>-apiserver 8081:80"
+    # Then browse to 127.0.0.1:8080 to login to the UI. This will then communicate with the apiserver via loopback on port tcp/8081
     # See https://docs.dependencytrack.org/getting-started/configuration/ for frontend ENV variables.
-#  podSecurityContext:
-#    fsGroup: 1000
+  # enabled needs to false for restricted SCC or true for anyuid SCC and Kubernetes
+  podSecurityContext:
+    enabled: false
+    fsGroup: 1000
+  # enabled needs to false for restricted SCC or true for anyuid SCC and Kubernetes
   securityContext:
+    enabled: true
     allowPrivilegeEscalation: false
     # rootfs cannot be R/O because there is some messing around with file generation and whatnot
     runAsUser: 101
@@ -54,7 +63,8 @@ frontend:
       memory: 512Mi
   nameOverride: ""
   fullnameOverride: ""
-  initContainers: []
+  initContainers:
+    enabled: true
   serviceAccount:
     # Specifies whether a service account should be created
     create: true
@@ -82,13 +92,20 @@ apiserver:
     size: 8Gi
     annotations: {}
     storageClass: ""
+  # enabled needs to false for restricted SCC or true for anyuid SCC and Kubernetes
   podSecurityContext:
+    enabled: true
     fsGroup: 1000
+  # enabled needs to false for restricted SCC or true for anyuid SCC and Kubernetes
   securityContext:
+    enabled: true
     readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 1000
     runAsGroup: 1000
+    capabilities:
+      drop:
+      - ALL
   service:
     type: ClusterIP
     port: 80
@@ -108,7 +125,8 @@ apiserver:
       memory: 16Gi
   nameOverride: ""
   fullnameOverride: ""
-  initContainers: []
+  initContainers:
+    enabled: true
   serviceAccount:
     # Specifies whether a service account should be created
     create: true
@@ -120,6 +138,22 @@ apiserver:
     initialDelaySeconds: 60
   livenessProbe:
     initialDelaySeconds: 60
+
+initContainer: #initContainer to check DB is up and contactable
+  enabled: true
+  name: wait-for-db
+  image: 
+    repository: busybox
+    tag: 1.33.0-uclibc
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []    
+  resources:
+    limits:
+      cpu: 200m
+      memory: 500Mi
+    requests:
+      cpu: 100m
+      memory: 200Mi
 
 ingress:
   enabled: false
@@ -139,3 +173,37 @@ postgresql:
   postgresqlUsername: deptrack
   postgresqlPassword: deptrack
   postgresqlDatabase: deptrack
+  serviceAccount:
+    enabled: true
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 250m
+    limits:
+      memory: 2Gi
+      cpu: 2
+  persistence:
+    enabled: true
+    accessMode: ReadWriteOnce
+    size: 20Gi
+    storageClass:
+    annotations:
+      helm.sh/resource-policy: "keep"
+  containerSecurityContext:
+   # enabled needs to false for restricted SCC or true for anyuid SCC and Kubernetes
+    enabled: true
+    runAsUser: 1001
+  securityContext:
+    # enabled needs to false for restricted SCC or true for anyuid SCC and Kubernetes
+    enabled: true
+    #fsGroup and runAsUser specifications below are not applied if enabled=false. enabled=false is the required setting for OpenShift "restricted SCC" to work successfully.
+    fsGroup: 1001
+    runAsUser: 1001
+  volumePermissions:
+    enabled: true
+    # if using restricted SCC set runAsUser: "auto" and if running under anyuid SCC - runAsUser needs to match the above
+    securityContext:
+      runAsUser: 1001
+  shmVolume:
+    chmod:
+      enabled: false

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -139,7 +139,7 @@ apiserver:
   livenessProbe:
     initialDelaySeconds: 60
 
-initContainer: #initContainer to check DB is up and contactable
+initContainer: # initContainer to check DB is up and contactable
   enabled: true
   name: wait-for-db
   image: 
@@ -196,7 +196,7 @@ postgresql:
   securityContext:
     # enabled needs to false for restricted SCC or true for anyuid SCC and Kubernetes
     enabled: true
-    #fsGroup and runAsUser specifications below are not applied if enabled=false. enabled=false is the required setting for OpenShift "restricted SCC" to work successfully.
+    # fsGroup and runAsUser specifications below are not applied if enabled=false. enabled=false is the required setting for OpenShift "restricted SCC" to work successfully.
     fsGroup: 1001
     runAsUser: 1001
   volumePermissions:

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -139,10 +139,11 @@ apiserver:
   livenessProbe:
     initialDelaySeconds: 60
 
-initContainer: # initContainer to check DB is up and contactable
+# initContainer to check DB is up and contactable
+initContainer:
   enabled: true
   name: wait-for-db
-  image: 
+  image:
     repository: busybox
     tag: 1.33.0-uclibc
     pullPolicy: IfNotPresent

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -73,7 +73,7 @@ apiserver:
   replicaCount: 1
   image:
     repository: dependencytrack/apiserver
-    tag: 4.2.0
+    tag: 4.2.1
     imagePullSecrets: []
     pullPolicy: IfNotPresent
   env: []

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -146,7 +146,7 @@ initContainer: # initContainer to check DB is up and contactable
     repository: busybox
     tag: 1.33.0-uclibc
     pullPolicy: IfNotPresent
-  imagePullSecrets: []    
+  imagePullSecrets: []
   resources:
     limits:
       cpu: 200m
@@ -190,7 +190,7 @@ postgresql:
     annotations:
       helm.sh/resource-policy: "keep"
   containerSecurityContext:
-   # enabled needs to false for restricted SCC or true for anyuid SCC and Kubernetes
+    # enabled needs to false for restricted SCC or true for anyuid SCC and Kubernetes
     enabled: true
     runAsUser: 1001
   securityContext:

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -177,35 +177,3 @@ postgresql:
   postgresqlDatabase: deptrack
   serviceAccount:
     enabled: true
-  resources:
-    requests:
-      memory: 256Mi
-      cpu: 250m
-    limits:
-      memory: 2Gi
-      cpu: 2
-  persistence:
-    enabled: true
-    accessMode: ReadWriteOnce
-    size: 20Gi
-    storageClass:
-    annotations:
-      helm.sh/resource-policy: "keep"
-  containerSecurityContext:
-    # enabled needs to false for restricted SCC or true for anyuid SCC and Kubernetes
-    enabled: true
-    runAsUser: 1001
-  securityContext:
-    # enabled needs to false for restricted SCC or true for anyuid SCC and Kubernetes
-    enabled: true
-    # fsGroup and runAsUser specifications below are not applied if enabled=false. enabled=false is the required setting for OpenShift "restricted SCC" to work successfully.
-    fsGroup: 1001
-    runAsUser: 1001
-  volumePermissions:
-    enabled: true
-    # if using restricted SCC set runAsUser: "auto" and if running under anyuid SCC - runAsUser needs to match the above
-    securityContext:
-      runAsUser: 1001
-  shmVolume:
-    chmod:
-      enabled: false


### PR DESCRIPTION
Following changes have been made:
 - Updated securityContext settings to enable OpenShift Restricted SCC compatibility.
 - Added in wait-for-db initContainer to ensure pods don't start before database is ready.
 - Exposed more PostgreSQL keys in values.yaml to simplify deployment parameter setting for OpenShift installs.
 - README updated to explain how to use this chart on OpenShift