### PR TITLE
Feature/implement probes

### DIFF
--- a/charts/dependency-track/Chart.yaml
+++ b/charts/dependency-track/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   Dependency-Track is an intelligent Software Supply Chain Component Analysis platform that allows organizations to identify and reduce risk from the use of third-party and open source components. Dependency-Track takes a unique and highly beneficial approach by leveraging the capabilities of Software Bill-of-Materials (SBOM). This approach provides capabilities that traditional Software Composition Analysis (SCA) solutions cannot achieve.
 name: dependency-track
 home: https://dependencytrack.org/
-version: 1.0.7
+version: 1.0.8
 icon: https://raw.githubusercontent.com/DependencyTrack/branding/master/dt-logo-black-text.svg
 keywords:
  - security

--- a/charts/dependency-track/templates/backend/deployment.yaml
+++ b/charts/dependency-track/templates/backend/deployment.yaml
@@ -61,6 +61,17 @@ spec:
         - name: api
           containerPort: 8080
           protocol: TCP
+        {{- if .Values.apiserver.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            port: {{ .Values.apiserver.livenessProbe.port | default 8080 }}
+            path: {{ .Values.apiserver.livenessProbe.path | default "/" }}
+          initialDelaySeconds: {{ .Values.apiserver.livenessProbe.initialDelaySeconds | default 45 }}
+          periodSeconds: {{ .Values.apiserver.livenessProbe.periodSeconds | default 10 }}
+          timeoutSeconds: {{ .Values.apiserver.livenessProbe.timeoutSeconds | default 5 }}
+          successThreshold: {{ .Values.apiserver.livenessProbe.successThreshold | default 3 }}
+          failureThreshold: {{ .Values.apiserver.livenessProbe.failureThreshold | default 3 }}
+        {{- end }}
       volumes:
       - name: tmp
         emptyDir: {}

--- a/charts/dependency-track/templates/backend/deployment.yaml
+++ b/charts/dependency-track/templates/backend/deployment.yaml
@@ -75,7 +75,7 @@ spec:
         {{- if .Values.apiserver.livenessProbe.enabled }}
         readinessProbe:
           httpGet:
-            port: {{ .Values.apiserver.readinessProbe.port | default 8080 }}
+            port: api
             path: {{ .Values.apiserver.readinessProbe.path | default "/" }}
           initialDelaySeconds: {{ .Values.apiserver.readinessProbe.initialDelaySeconds | default 45 }}
           periodSeconds: {{ .Values.apiserver.readinessProbe.periodSeconds | default 10 }}

--- a/charts/dependency-track/templates/backend/deployment.yaml
+++ b/charts/dependency-track/templates/backend/deployment.yaml
@@ -65,23 +65,23 @@ spec:
         livenessProbe:
           httpGet:
             port: api
-            path: {{ .Values.apiserver.livenessProbe.path | default "/" }}
-          initialDelaySeconds: {{ .Values.apiserver.livenessProbe.initialDelaySeconds | default 45 }}
-          periodSeconds: {{ .Values.apiserver.livenessProbe.periodSeconds | default 10 }}
-          timeoutSeconds: {{ .Values.apiserver.livenessProbe.timeoutSeconds | default 5 }}
-          successThreshold: {{ .Values.apiserver.livenessProbe.successThreshold | default 1 }}
-          failureThreshold: {{ .Values.apiserver.livenessProbe.failureThreshold | default 3 }}
+            path: {{ .Values.apiserver.livenessProbe.path }}
+          initialDelaySeconds: {{ .Values.apiserver.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.apiserver.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.apiserver.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.apiserver.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.apiserver.livenessProbe.failureThreshold }}
         {{- end }}
         {{- if .Values.apiserver.livenessProbe.enabled }}
         readinessProbe:
           httpGet:
             port: api
-            path: {{ .Values.apiserver.readinessProbe.path | default "/" }}
-          initialDelaySeconds: {{ .Values.apiserver.readinessProbe.initialDelaySeconds | default 45 }}
-          periodSeconds: {{ .Values.apiserver.readinessProbe.periodSeconds | default 10 }}
-          timeoutSeconds: {{ .Values.apiserver.readinessProbe.timeoutSeconds | default 5 }}
-          successThreshold: {{ .Values.apiserver.readinessProbe.successThreshold | default 1 }}
-          failureThreshold: {{ .Values.apiserver.readinessProbe.failureThreshold | default 3 }}
+            path: {{ .Values.apiserver.readinessProbe.path }}
+          initialDelaySeconds: {{ .Values.apiserver.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.apiserver.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.apiserver.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.apiserver.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.apiserver.readinessProbe.failureThreshold }}
         {{- end }}
       volumes:
       - name: tmp

--- a/charts/dependency-track/templates/backend/deployment.yaml
+++ b/charts/dependency-track/templates/backend/deployment.yaml
@@ -69,8 +69,19 @@ spec:
           initialDelaySeconds: {{ .Values.apiserver.livenessProbe.initialDelaySeconds | default 45 }}
           periodSeconds: {{ .Values.apiserver.livenessProbe.periodSeconds | default 10 }}
           timeoutSeconds: {{ .Values.apiserver.livenessProbe.timeoutSeconds | default 5 }}
-          successThreshold: {{ .Values.apiserver.livenessProbe.successThreshold | default 3 }}
+          successThreshold: {{ .Values.apiserver.livenessProbe.successThreshold | default 1 }}
           failureThreshold: {{ .Values.apiserver.livenessProbe.failureThreshold | default 3 }}
+        {{- end }}
+        {{- if .Values.apiserver.livenessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            port: {{ .Values.apiserver.readinessProbe.port | default 8080 }}
+            path: {{ .Values.apiserver.readinessProbe.path | default "/" }}
+          initialDelaySeconds: {{ .Values.apiserver.readinessProbe.initialDelaySeconds | default 45 }}
+          periodSeconds: {{ .Values.apiserver.readinessProbe.periodSeconds | default 10 }}
+          timeoutSeconds: {{ .Values.apiserver.readinessProbe.timeoutSeconds | default 5 }}
+          successThreshold: {{ .Values.apiserver.readinessProbe.successThreshold | default 1 }}
+          failureThreshold: {{ .Values.apiserver.readinessProbe.failureThreshold | default 3 }}
         {{- end }}
       volumes:
       - name: tmp

--- a/charts/dependency-track/templates/backend/deployment.yaml
+++ b/charts/dependency-track/templates/backend/deployment.yaml
@@ -64,7 +64,7 @@ spec:
         {{- if .Values.apiserver.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            port: {{ .Values.apiserver.livenessProbe.port | default 8080 }}
+            port: api
             path: {{ .Values.apiserver.livenessProbe.path | default "/" }}
           initialDelaySeconds: {{ .Values.apiserver.livenessProbe.initialDelaySeconds | default 45 }}
           periodSeconds: {{ .Values.apiserver.livenessProbe.periodSeconds | default 10 }}

--- a/charts/dependency-track/templates/frontend/deployment.yaml
+++ b/charts/dependency-track/templates/frontend/deployment.yaml
@@ -44,8 +44,19 @@ spec:
           initialDelaySeconds: {{ .Values.frontend.livenessProbe.initialDelaySeconds | default 45 }}
           periodSeconds: {{ .Values.frontend.livenessProbe.periodSeconds | default 10 }}
           timeoutSeconds: {{ .Values.frontend.livenessProbe.timeoutSeconds | default 2 }}
-          successThreshold: {{ .Values.frontend.livenessProbe.successThreshold | default 3 }}
+          successThreshold: {{ .Values.frontend.livenessProbe.successThreshold | default 1 }}
           failureThreshold: {{ .Values.frontend.livenessProbe.failureThreshold | default 3 }}
+        {{- end }}
+        {{- if .Values.apiserver.livenessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            port: {{ .Values.frontend.readinessProbe.port | default 8080 }}
+            path: {{ .Values.frontend.readinessProbe.path | default "/" }}
+          initialDelaySeconds: {{ .Values.frontend.readinessProbe.initialDelaySeconds | default 45 }}
+          periodSeconds: {{ .Values.frontend.readinessProbe.periodSeconds | default 10 }}
+          timeoutSeconds: {{ .Values.frontend.readinessProbe.timeoutSeconds | default 5 }}
+          successThreshold: {{ .Values.frontend.readinessProbe.successThreshold | default 1 }}
+          failureThreshold: {{ .Values.frontend.readinessProbe.failureThreshold | default 3 }}
         {{- end }}
       volumes:
       - name: tmp

--- a/charts/dependency-track/templates/frontend/deployment.yaml
+++ b/charts/dependency-track/templates/frontend/deployment.yaml
@@ -40,23 +40,23 @@ spec:
         livenessProbe:
           httpGet:
             port: http
-            path: {{ .Values.frontend.livenessProbe.path | default "/" }}
-          initialDelaySeconds: {{ .Values.frontend.livenessProbe.initialDelaySeconds | default 45 }}
-          periodSeconds: {{ .Values.frontend.livenessProbe.periodSeconds | default 10 }}
-          timeoutSeconds: {{ .Values.frontend.livenessProbe.timeoutSeconds | default 2 }}
-          successThreshold: {{ .Values.frontend.livenessProbe.successThreshold | default 1 }}
-          failureThreshold: {{ .Values.frontend.livenessProbe.failureThreshold | default 3 }}
+            path: {{ .Values.frontend.livenessProbe.path }}
+          initialDelaySeconds: {{ .Values.frontend.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.frontend.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.frontend.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.frontend.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.frontend.livenessProbe.failureThreshold }}
         {{- end }}
         {{- if .Values.apiserver.livenessProbe.enabled }}
         readinessProbe:
           httpGet:
             port: http
-            path: {{ .Values.frontend.readinessProbe.path | default "/" }}
-          initialDelaySeconds: {{ .Values.frontend.readinessProbe.initialDelaySeconds | default 45 }}
-          periodSeconds: {{ .Values.frontend.readinessProbe.periodSeconds | default 10 }}
-          timeoutSeconds: {{ .Values.frontend.readinessProbe.timeoutSeconds | default 5 }}
-          successThreshold: {{ .Values.frontend.readinessProbe.successThreshold | default 1 }}
-          failureThreshold: {{ .Values.frontend.readinessProbe.failureThreshold | default 3 }}
+            path: {{ .Values.frontend.readinessProbe.path }}
+          initialDelaySeconds: {{ .Values.frontend.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.frontend.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.frontend.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.frontend.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.frontend.readinessProbe.failureThreshold }}
         {{- end }}
       volumes:
       - name: tmp

--- a/charts/dependency-track/templates/frontend/deployment.yaml
+++ b/charts/dependency-track/templates/frontend/deployment.yaml
@@ -50,7 +50,7 @@ spec:
         {{- if .Values.apiserver.livenessProbe.enabled }}
         readinessProbe:
           httpGet:
-            port: {{ .Values.frontend.readinessProbe.port | default 8080 }}
+            port: http
             path: {{ .Values.frontend.readinessProbe.path | default "/" }}
           initialDelaySeconds: {{ .Values.frontend.readinessProbe.initialDelaySeconds | default 45 }}
           periodSeconds: {{ .Values.frontend.readinessProbe.periodSeconds | default 10 }}

--- a/charts/dependency-track/templates/frontend/deployment.yaml
+++ b/charts/dependency-track/templates/frontend/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         {{- if .Values.frontend.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            port: {{ .Values.frontend.livenessProbe.port | default 8080 }}
+            port: http
             path: {{ .Values.frontend.livenessProbe.path | default "/" }}
           initialDelaySeconds: {{ .Values.frontend.livenessProbe.initialDelaySeconds | default 45 }}
           periodSeconds: {{ .Values.frontend.livenessProbe.periodSeconds | default 10 }}

--- a/charts/dependency-track/templates/frontend/deployment.yaml
+++ b/charts/dependency-track/templates/frontend/deployment.yaml
@@ -36,6 +36,17 @@ spec:
           mountPath: /tmp
         #- name: config
         #  mountPath: /app/static
+        {{- if .Values.frontend.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            port: {{ .Values.frontend.livenessProbe.port | default 8080 }}
+            path: {{ .Values.frontend.livenessProbe.path | default "/" }}
+          initialDelaySeconds: {{ .Values.frontend.livenessProbe.initialDelaySeconds | default 45 }}
+          periodSeconds: {{ .Values.frontend.livenessProbe.periodSeconds | default 10 }}
+          timeoutSeconds: {{ .Values.frontend.livenessProbe.timeoutSeconds | default 2 }}
+          successThreshold: {{ .Values.frontend.livenessProbe.successThreshold | default 3 }}
+          failureThreshold: {{ .Values.frontend.livenessProbe.failureThreshold | default 3 }}
+        {{- end }}
       volumes:
       - name: tmp
         emptyDir: {}

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -71,6 +71,15 @@ frontend:
     timeoutSeconds: ""
     successThreshold: ""
     failureThreshold: ""
+  readinessProbe:
+    enabled: true
+    port: ""
+    path: ""
+    initialDelaySeconds: 60
+    periodSeconds: ""
+    timeoutSeconds: ""
+    successThreshold: ""
+    failureThreshold: ""
 
 
 # The apiserver
@@ -123,6 +132,15 @@ apiserver:
     name: apiserver-serviceaccount
   # See https://docs.dependencytrack.org/getting-started/configuration/ for backend configuration options.
   livenessProbe:
+    enabled: true
+    port: ""
+    path: ""
+    initialDelaySeconds: 60
+    periodSeconds: ""
+    timeoutSeconds: ""
+    successThreshold: ""
+    failureThreshold: ""
+  readinessProbe:
     enabled: true
     port: ""
     path: ""

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -64,22 +64,20 @@ frontend:
     name: frontend-serviceaccount
   livenessProbe:
     enabled: true
-    port: ""
-    path: ""
+    path: "/"
     initialDelaySeconds: 60
-    periodSeconds: ""
-    timeoutSeconds: ""
-    successThreshold: ""
-    failureThreshold: ""
+    periodSeconds: 10
+    timeoutSeconds: 2
+    successThreshold: 1
+    failureThreshold: 3
   readinessProbe:
     enabled: true
-    port: ""
-    path: ""
+    path: "/"
     initialDelaySeconds: 60
-    periodSeconds: ""
-    timeoutSeconds: ""
-    successThreshold: ""
-    failureThreshold: ""
+    periodSeconds: 10
+    timeoutSeconds: 2
+    successThreshold: 1
+    failureThreshold: 3
 
 
 # The apiserver
@@ -133,22 +131,20 @@ apiserver:
   # See https://docs.dependencytrack.org/getting-started/configuration/ for backend configuration options.
   livenessProbe:
     enabled: true
-    port: ""
-    path: ""
+    path: "/"
     initialDelaySeconds: 60
-    periodSeconds: ""
-    timeoutSeconds: ""
-    successThreshold: ""
-    failureThreshold: ""
+    periodSeconds: 10
+    timeoutSeconds: 2
+    successThreshold: 1
+    failureThreshold: 3
   readinessProbe:
     enabled: true
-    port: ""
-    path: ""
+    path: "/"
     initialDelaySeconds: 60
-    periodSeconds: ""
-    timeoutSeconds: ""
-    successThreshold: ""
-    failureThreshold: ""
+    periodSeconds: 10
+    timeoutSeconds: 2
+    successThreshold: 1
+    failureThreshold: 3
 
 
 ingress:

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -131,7 +131,7 @@ apiserver:
   # See https://docs.dependencytrack.org/getting-started/configuration/ for backend configuration options.
   livenessProbe:
     enabled: true
-    path: "/"
+    path: "/api/version"
     initialDelaySeconds: 60
     periodSeconds: 10
     timeoutSeconds: 2

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -62,10 +62,16 @@ frontend:
     # The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     name: frontend-serviceaccount
-  readinessProbe:
-    initialDelaySeconds: 60
   livenessProbe:
+    enabled: true
+    port: ""
+    path: ""
     initialDelaySeconds: 60
+    periodSeconds: ""
+    timeoutSeconds: ""
+    successThreshold: ""
+    failureThreshold: ""
+
 
 # The apiserver
 apiserver:
@@ -116,10 +122,16 @@ apiserver:
     # If not set and create is true, a name is generated using the fullname template
     name: apiserver-serviceaccount
   # See https://docs.dependencytrack.org/getting-started/configuration/ for backend configuration options.
-  readinessProbe:
-    initialDelaySeconds: 60
   livenessProbe:
+    enabled: true
+    port: ""
+    path: ""
     initialDelaySeconds: 60
+    periodSeconds: ""
+    timeoutSeconds: ""
+    successThreshold: ""
+    failureThreshold: ""
+
 
 ingress:
   enabled: false


### PR DESCRIPTION
@davidkarlsen let's discuss whether or not startupProbes are actually needed for DependencyTrack. Wouldn't the combination of liveness and readiness suffice? If it takes too long to start up, liveness will restart it anyways until it enters a CrashLoopBackOff state?

Open to suggestions, and to other defaults, but as a bare minimum we should probably wait up to a minute before doing any checks (this is an assumption on my side. I've never actually seen how long DT uses to start up.)