### PR TITLE
Bump apiserver to 4.3.4 - new release

### DIFF
--- a/charts/dependency-track/Chart.yaml
+++ b/charts/dependency-track/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
-appVersion: 4.3.3
+appVersion: 4.3.4
 description: |
   Dependency-Track is an intelligent Software Supply Chain Component Analysis platform that allows organizations to identify and reduce risk from the use of third-party and open source components. Dependency-Track takes a unique and highly beneficial approach by leveraging the capabilities of Software Bill-of-Materials (SBOM). This approach provides capabilities that traditional Software Composition Analysis (SCA) solutions cannot achieve.
 name: dependency-track
 home: https://dependencytrack.org/
-version: 1.1.2
+version: 1.1.3
 icon: https://raw.githubusercontent.com/DependencyTrack/branding/master/dt-logo-black-text.svg
 keywords:
  - security

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -89,7 +89,7 @@ apiserver:
   replicaCount: 1
   image:
     repository: dependencytrack/apiserver
-    tag: 4.3.3
+    tag: 4.3.4
     pullPolicy: IfNotPresent
   env: []
   persistentVolume:


### PR DESCRIPTION
Release notes: https://docs.dependencytrack.org/2021/08/31/v4.3.4/