### PR TITLE
Bump frontend to 4.4.0, apiserver to 4.4.1, new chart version

### DIFF
--- a/charts/dependency-track/Chart.yaml
+++ b/charts/dependency-track/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
-appVersion: 4.3.6
+appVersion: 4.4.0
 description: |
   Dependency-Track is an intelligent Software Supply Chain Component Analysis platform that allows organizations to identify and reduce risk from the use of third-party and open source components. Dependency-Track takes a unique and highly beneficial approach by leveraging the capabilities of Software Bill-of-Materials (SBOM). This approach provides capabilities that traditional Software Composition Analysis (SCA) solutions cannot achieve.
 name: dependency-track
 home: https://dependencytrack.org/
-version: 1.2.0
+version: 1.3.0
 icon: https://raw.githubusercontent.com/DependencyTrack/branding/master/dt-logo-black-text.svg
 keywords:
  - security

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -15,7 +15,7 @@ frontend:
   replicaCount: 2
   image:
     repository: dependencytrack/frontend
-    tag: 4.3.1
+    tag: 4.4.0
     pullPolicy: IfNotPresent
   # https://github.com/DependencyTrack/frontend/issues/60
   # configmap:
@@ -93,7 +93,7 @@ apiserver:
   replicaCount: 1
   image:
     repository: dependencytrack/apiserver
-    tag: 4.3.6
+    tag: 4.4.1
     pullPolicy: IfNotPresent
   env: []
   persistentVolume:


### PR DESCRIPTION
I see that the apiserver has a new patch release, so including that just in case.