### PR TITLE
dependency-track: swap backend/frontend serviceaccount labels

### DIFF
--- a/charts/dependency-track/Chart.yaml
+++ b/charts/dependency-track/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   Dependency-Track is an intelligent Software Supply Chain Component Analysis platform that allows organizations to identify and reduce risk from the use of third-party and open source components. Dependency-Track takes a unique and highly beneficial approach by leveraging the capabilities of Software Bill-of-Materials (SBOM). This approach provides capabilities that traditional Software Composition Analysis (SCA) solutions cannot achieve.
 name: dependency-track
 home: https://dependencytrack.org/
-version: 1.3.2
+version: 1.3.3
 icon: https://raw.githubusercontent.com/DependencyTrack/branding/master/dt-logo-black-text.svg
 keywords:
  - security

--- a/charts/dependency-track/templates/backend/serviceaccount.yaml
+++ b/charts/dependency-track/templates/backend/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "common.names.fullname" . }}-apiserver
-  labels: {{- include "frontend.labels.standard" . | nindent 4 }}
+  labels: {{- include "backend.labels.standard" . | nindent 4 }}
   {{- with .Values.apiserver.serviceAccount.annotations }}
   annotations: {{- . | toYaml | nindent 4 }}
   {{ end }}

--- a/charts/dependency-track/templates/frontend/serviceaccount.yaml
+++ b/charts/dependency-track/templates/frontend/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "common.names.fullname" . }}-frontend
-  labels: {{- include "backend.labels.standard" . | nindent 4 }}
+  labels: {{- include "frontend.labels.standard" . | nindent 4 }}
   {{- with .Values.frontend.serviceAccount.annotations }}
   annotations: {{- . | toYaml | nindent 4 }}
   {{ end }}


### PR DESCRIPTION
The backend serviceaccount has the frontend labels and vice-versa.

Signed-off-by: Rob Best <robertbest89@gmail.com>