### PR TITLE
#164 updating dependency-tack version to 4.5.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ into the project you can [fork this repository][2] and
 Sign-off commits to pass [DCO-checks][4].
 
 
-[1]: https://github.com/evryfs/helm-chartstd/issues
+[1]: https://github.com/evryfs/helm-charts/issues
 [2]: https://help.github.com/articles/fork-a-repo/
 [3]: https://help.github.com/articles/about-pull-requests/
 [4]: https://developercertificate.org/

--- a/charts/dependency-track/Chart.lock
+++ b/charts/dependency-track/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
   version: 10.10.3
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.11.3
-digest: sha256:92b34febec462b059ac88667f59da57160239b9a0212b3d700e051958f170d1d
-generated: "2022-03-06T19:08:47.130688+01:00"
+  version: 1.15.2
+digest: sha256:eab20272f0faf10416929a238bddf220aaee1d754962c4aa17495fae1c705312
+generated: "2022-06-03T14:58:48.223092+02:00"

--- a/charts/dependency-track/Chart.yaml
+++ b/charts/dependency-track/Chart.yaml
@@ -26,5 +26,5 @@ dependencies:
   repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
   condition: postgresql.enabled
 - name: common
-  version: 1.11.x
+  version: 1.15.x
   repository: https://charts.bitnami.com/bitnami

--- a/charts/dependency-track/Chart.yaml
+++ b/charts/dependency-track/Chart.yaml
@@ -23,7 +23,7 @@ sources:
 dependencies:
 - name: postgresql
   version: ~10.10
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
   condition: postgresql.enabled
 - name: common
   version: 1.11.x

--- a/charts/dependency-track/Chart.yaml
+++ b/charts/dependency-track/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
-appVersion: 4.4.2
+appVersion: 4.5.0
 description: |
   Dependency-Track is an intelligent Software Supply Chain Component Analysis platform that allows organizations to identify and reduce risk from the use of third-party and open source components. Dependency-Track takes a unique and highly beneficial approach by leveraging the capabilities of Software Bill-of-Materials (SBOM). This approach provides capabilities that traditional Software Composition Analysis (SCA) solutions cannot achieve.
 name: dependency-track
 home: https://dependencytrack.org/
-version: 1.3.5
+version: 1.4.0
 icon: https://raw.githubusercontent.com/DependencyTrack/branding/master/dt-logo-black-text.svg
 keywords:
  - security

--- a/charts/dependency-track/README.md
+++ b/charts/dependency-track/README.md
@@ -1,6 +1,6 @@
 # dependency-track
 
-![Version: 1.3.5](https://img.shields.io/badge/Version-1.3.5-informational?style=flat-square) ![AppVersion: 4.4.2](https://img.shields.io/badge/AppVersion-4.4.2-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![AppVersion: 4.5.0](https://img.shields.io/badge/AppVersion-4.5.0-informational?style=flat-square)
 
 Dependency-Track is an intelligent Software Supply Chain Component Analysis platform that allows organizations to identify and reduce risk from the use of third-party and open source components. Dependency-Track takes a unique and highly beneficial approach by leveraging the capabilities of Software Bill-of-Materials (SBOM). This approach provides capabilities that traditional Software Composition Analysis (SCA) solutions cannot achieve.
 
@@ -10,8 +10,8 @@ Dependency-Track is an intelligent Software Supply Chain Component Analysis plat
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| davidkarlsen | david@davidkarlsen.com |  |
-| otterian | eth0linak@gmail.com |  |
+| davidkarlsen | <david@davidkarlsen.com> |  |
+| otterian | <eth0linak@gmail.com> |  |
 
 ## Source Code
 
@@ -29,7 +29,7 @@ Dependency-Track is an intelligent Software Supply Chain Component Analysis plat
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| apiserver | object | `{"affinity":{},"emptyDir":{"sizeLimit":"8Gi"},"enabled":true,"env":[],"fullnameOverride":"","image":{"pullPolicy":"IfNotPresent","repository":"dependencytrack/apiserver","tag":"4.4.2"},"initContainers":[],"livenessProbe":{"enabled":true,"failureThreshold":3,"initialDelaySeconds":60,"path":"/api/version","periodSeconds":10,"successThreshold":1,"timeoutSeconds":2},"nameOverride":"","nodeSelector":{},"persistentVolume":{"accessModes":["ReadWriteOnce"],"annotations":{},"enabled":true,"size":"8Gi","storageClass":""},"podSecurityContext":{"fsGroup":1000},"readinessProbe":{"enabled":true,"failureThreshold":3,"initialDelaySeconds":60,"path":"/","periodSeconds":10,"successThreshold":1,"timeoutSeconds":2},"replicaCount":1,"resources":{"limits":{"cpu":4,"memory":"16Gi"},"requests":{"cpu":2,"memory":"4608Mi"}},"securityContext":{"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000},"service":{"annotations":{},"port":80,"type":"ClusterIP"},"serviceAccount":{"annotations":{},"create":true,"name":"apiserver-serviceaccount"},"tolerations":[]}` | config of the apiserver |
+| apiserver | object | `{"affinity":{},"emptyDir":{"sizeLimit":"8Gi"},"enabled":true,"env":[],"fullnameOverride":"","image":{"pullPolicy":"IfNotPresent","repository":"dependencytrack/apiserver","tag":"4.5.0"},"initContainers":[],"livenessProbe":{"enabled":true,"failureThreshold":3,"initialDelaySeconds":60,"path":"/api/version","periodSeconds":10,"successThreshold":1,"timeoutSeconds":2},"nameOverride":"","nodeSelector":{},"persistentVolume":{"accessModes":["ReadWriteOnce"],"annotations":{},"enabled":true,"size":"8Gi","storageClass":""},"podSecurityContext":{"fsGroup":1000},"readinessProbe":{"enabled":true,"failureThreshold":3,"initialDelaySeconds":60,"path":"/","periodSeconds":10,"successThreshold":1,"timeoutSeconds":2},"replicaCount":1,"resources":{"limits":{"cpu":4,"memory":"16Gi"},"requests":{"cpu":2,"memory":"4608Mi"}},"securityContext":{"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000},"service":{"annotations":{},"port":80,"type":"ClusterIP"},"serviceAccount":{"annotations":{},"create":true,"name":"apiserver-serviceaccount"},"tolerations":[]}` | config of the apiserver |
 | frontend | object | `{"affinity":{},"emptyDir":{"sizeLimit":"8Gi"},"enabled":true,"env":[{"name":"API_BASE_URL","value":""}],"fullnameOverride":"","image":{"pullPolicy":"IfNotPresent","repository":"dependencytrack/frontend","tag":"4.4.0"},"initContainers":[],"livenessProbe":{"enabled":true,"failureThreshold":3,"initialDelaySeconds":60,"path":"/","periodSeconds":10,"successThreshold":1,"timeoutSeconds":2},"nameOverride":"","nodeSelector":{},"readinessProbe":{"enabled":true,"failureThreshold":3,"initialDelaySeconds":60,"path":"/","periodSeconds":10,"successThreshold":1,"timeoutSeconds":2},"replicaCount":2,"resources":{"limits":{"cpu":1,"memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}},"securityContext":{"allowPrivilegeEscalation":false,"runAsUser":101},"service":{"annotations":{},"port":80,"type":"ClusterIP"},"serviceAccount":{"annotations":{},"create":true,"name":"frontend-serviceaccount"},"tolerations":[]}` | config of the frontend |
 | frontend.env | list | `[{"name":"API_BASE_URL","value":""}]` | See https://docs.dependencytrack.org/getting-started/configuration/ for frontend ENV variables. |
 | global | object | `{"imageRegistry":"docker.io"}` | global configuration |
@@ -37,4 +37,4 @@ Dependency-Track is an intelligent Software Supply Chain Component Analysis plat
 | postgresql | object | `{"enabled":true,"postgresqlDatabase":"deptrack","postgresqlPassword":"deptrack","postgresqlUsername":"deptrack"}` | configuration of postgres |
 
 ----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.7.0](https://github.com/norwoodj/helm-docs/releases/v1.7.0)
+Autogenerated from chart metadata using [helm-docs v1.10.0](https://github.com/norwoodj/helm-docs/releases/v1.10.0)

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -93,7 +93,7 @@ apiserver:
   replicaCount: 1
   image:
     repository: dependencytrack/apiserver
-    tag: 4.4.2
+    tag: 4.5.0
     pullPolicy: IfNotPresent
   env: []
   persistentVolume:

--- a/ct-config.yaml
+++ b/ct-config.yaml
@@ -4,3 +4,4 @@ chart-dirs:
   - charts
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
+  - bitnami-pre2022=https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami


### PR DESCRIPTION
- updated dependency-track version to 4.5.0 / trying to resolve: https://github.com/evryfs/helm-charts/issues/164
- bumped chart version to 1.3.6
- ran helm-docs
- fixed link to issues in CONTRIBUTING.md

- ran the test.yml ci in personal fork with dummy version of other charts to pass linting. Dependency-track test seems to be ok. (https://github.com/magnuskiro/evryfs-helm-charts/actions/runs/2414702723)