### PR TITLE
Update Dependency Track To 4.6.0

### DIFF
--- a/charts/dependency-track/Chart.yaml
+++ b/charts/dependency-track/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
-appVersion: 4.5.0
+appVersion: 4.6.0
 description: |
   Dependency-Track is an intelligent Software Supply Chain Component Analysis platform that allows organizations to identify and reduce risk from the use of third-party and open source components. Dependency-Track takes a unique and highly beneficial approach by leveraging the capabilities of Software Bill-of-Materials (SBOM). This approach provides capabilities that traditional Software Composition Analysis (SCA) solutions cannot achieve.
 name: dependency-track
 home: https://dependencytrack.org/
-version: 1.4.1
+version: 1.5.0
 icon: https://raw.githubusercontent.com/DependencyTrack/branding/master/dt-logo-black-text.svg
 keywords:
  - security

--- a/charts/dependency-track/Chart.yaml
+++ b/charts/dependency-track/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 4.6.0
+appVersion: 4.6.1
 description: |
   Dependency-Track is an intelligent Software Supply Chain Component Analysis platform that allows organizations to identify and reduce risk from the use of third-party and open source components. Dependency-Track takes a unique and highly beneficial approach by leveraging the capabilities of Software Bill-of-Materials (SBOM). This approach provides capabilities that traditional Software Composition Analysis (SCA) solutions cannot achieve.
 name: dependency-track

--- a/charts/dependency-track/README.md
+++ b/charts/dependency-track/README.md
@@ -1,6 +1,6 @@
 # dependency-track
 
-![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![AppVersion: 4.5.0](https://img.shields.io/badge/AppVersion-4.5.0-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![AppVersion: 4.6.0](https://img.shields.io/badge/AppVersion-4.6.0-informational?style=flat-square)
 
 Dependency-Track is an intelligent Software Supply Chain Component Analysis platform that allows organizations to identify and reduce risk from the use of third-party and open source components. Dependency-Track takes a unique and highly beneficial approach by leveraging the capabilities of Software Bill-of-Materials (SBOM). This approach provides capabilities that traditional Software Composition Analysis (SCA) solutions cannot achieve.
 

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -93,7 +93,7 @@ apiserver:
   replicaCount: 1
   image:
     repository: dependencytrack/apiserver
-    tag: 4.6.0
+    tag: 4.6.1
     pullPolicy: IfNotPresent
   env: []
   persistentVolume:

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -15,7 +15,7 @@ frontend:
   replicaCount: 2
   image:
     repository: dependencytrack/frontend
-    tag: 4.4.0
+    tag: 4.6.0
     pullPolicy: IfNotPresent
   # https://github.com/DependencyTrack/frontend/issues/60
   # configmap:
@@ -93,7 +93,7 @@ apiserver:
   replicaCount: 1
   image:
     repository: dependencytrack/apiserver
-    tag: 4.5.0
+    tag: 4.6.0
     pullPolicy: IfNotPresent
   env: []
   persistentVolume:


### PR DESCRIPTION
4.6.0 of api and front end released

I'm not sure if this is the _only_ changes required to update the helm chart.

I also noticed that the current chart was using a mismatch of api and frontend, so have corrected this