### PR TITLE
Bumped image tag for frontend and apiserver to 4.7.0

### DIFF
--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -16,7 +16,7 @@ frontend:
   replicaCount: 2
   image:
     repository: dependencytrack/frontend
-    tag: 4.6.1
+    tag: 4.7.0
     pullPolicy: IfNotPresent
   # https://github.com/DependencyTrack/frontend/issues/60
   # configmap:
@@ -95,7 +95,7 @@ apiserver:
   replicaCount: 1
   image:
     repository: dependencytrack/apiserver
-    tag: 4.6.3
+    tag: 4.7.0
     pullPolicy: IfNotPresent
   env: []
   persistentVolume:


### PR DESCRIPTION
Ref:
- dependencytrack/frontend: https://hub.docker.com/layers/dependencytrack/frontend/4.7.0/images/sha256-66130dcba88c448a7218aa117d24ff37e59547975641f0f2789d5add6a65610d?context=explore
- dependencytrack/apiserver: https://hub.docker.com/layers/dependencytrack/apiserver/4.7.0/images/sha256-ac0ca24e97a5445d16b2429d6307673a6404b6b54ace206c6027c264cf64ea48?context=explore