### PR TITLE
added priorityClassName support for github-actions-runner-operator

### DIFF
--- a/charts/github-actions-runner-operator/templates/deployment.yaml
+++ b/charts/github-actions-runner-operator/templates/deployment.yaml
@@ -64,6 +64,9 @@ spec:
       {{- with .Values.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       {{- with .Values.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/github-actions-runner-operator/values.yaml
+++ b/charts/github-actions-runner-operator/values.yaml
@@ -59,6 +59,8 @@ resources: {}
 
 nodeSelector: {}
 
+priorityClassName: ""
+
 tolerations: []
 
 affinity: {}


### PR DESCRIPTION
added support for kubernetes [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)

Value is optional and default is ""
If value is not set or empty then priorityClassName will be ignored in deployment