### PR TITLE
Add custom ALPINE_DATABASE_URL value in dependecy-track

### DIFF
--- a/charts/dependency-track/templates/backend/deployment.yaml
+++ b/charts/dependency-track/templates/backend/deployment.yaml
@@ -45,7 +45,11 @@ spec:
         - name: ALPINE_DATABASE_DRIVER
           value: "org.postgresql.Driver"
         - name: ALPINE_DATABASE_URL
+        {{- if .Values.postgresql.database_url }}
+          value: {{ .Values.postgresql.database_url }}
+        {{- else }}
           value: jdbc:postgresql://{{ .Release.Name }}-postgresql/{{ .Values.postgresql.postgresqlDatabase }}
+        {{- end }}
         - name: ALPINE_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
We do need some transformation for the dependency-track helm chart: the possibility to specify our own `ALPINE_DATABASE_URL` along with having `ALPINE_DATABASE_PASSWORD` as a secretRef - we use external-secret controller to provision secrets from Hashicorp Vault.

Thanks!